### PR TITLE
New "default status" and a few wording tweaks

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,12 @@
   infer it?
 - presenceDesc = "In a conversation; come join if you like"; -- have we made
   it possible / obvious how to go to where someone else is??
+- need to think about screen real estate on small (laptop, ipad) screens --
+  e.g.
+       - the title bar across the top uses a lot of space
+       - the "live questions to the speakers" goes entirely off the bottom
+- The pop-up for someone's name in the lobby does not include their textual
+  status (or profile); the one on the left sidebar does
 
 # Notes from SCW
 
@@ -26,7 +32,7 @@ Just talking with Richard and he mentioned two ideas for Clowdr:
   question needs to join the queue and wait for their turn. Any number of
   people can observe the discussion
 
-# Notes from / PLMW debried
+# Notes from / PLMW debrief
 
 - Lots of disagreement about whether lurking is a good thing.  Roopsha
   observed that shy people may have a lot of trouble goijng from lurking to

--- a/TODO.md
+++ b/TODO.md
@@ -2,14 +2,29 @@
 
 - Add "Status: " before the dot
 - Add a new kind of status color, with a label like "Default"
+- Try to rename the "End call" button to "Back to lobby"
+- dntWaiver = "Only you can see this status. Others will still see your
+  presence in public rooms, but won't see a status" -- ... But this is the
+  only status that will be displayed as blank, so won't people be able to
+  infer it?
+- presenceDesc = "In a conversation; come join if you like"; -- have we made
+  it possible / obvious how to go to where someone else is??
 
 # Notes from SCW
 
 Just talking with Richard and he mentioned two ideas for Clowdr:
 
-- "Random" social event.  Everyone who signs up gets placed in a random room for a short meet & greet. I guess this is similar to Zoom's breakout room feature, but we should look into how many people this could support at once. A better option would be to let people specify/select a few topics when they sign up that they are interested to increase the chance that the interactions go well.
+- "Random" social event.  Everyone who signs up gets placed in a random room
+  for a short meet & greet. I guess this is similar to Zoom's breakout room
+  feature, but we should look into how many people this could support at
+  once. A better option would be to let people specify/select a few topics
+  when they sign up that they are interested to increase the chance that the
+  interactions go well.
 
-- Q&A specific video room. Only three video streams allowed at a time: author, current question asker and moderator. Any one who wants to ask a question needs to join the queue and wait for their turn. Any number of people can observe the discussion.
+- Q&A specific video room. Only three video streams allowed at a time:
+  author, current question asker and moderator. Any one who wants to ask a
+  question needs to join the queue and wait for their turn. Any number of
+  people can observe the discussion
 
 # Notes from / PLMW debried
 

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -113,9 +113,8 @@ class Landing extends Component {
 </center>
 
             <p><b>CLOWDR</b> is a community-driven effort to create a new platform to 
-                support <b>C</b>onferences <b>L</b>ocated <b>O</b>nline <b>W</b>ith <b>D</b>igital <b>R</b>esources. (Clowder
-                is <a href="https://www.merriam-webster.com/dictionary/clowder" rel="noopener noreferrer" target="_blank">a group of cats</a>, 
-                which is another suitable meaning of the word here &#128049;)
+        support <b>C</b>onferences <b>L</b>ocated <b>O</b>nline <b>W</b>ith <b>D</b>igital <b>R</b>esources. (Also, a clowder
+                is <a href="https://www.merriam-webster.com/dictionary/clowder" rel="noopener noreferrer" target="_blank">a group of cats</a> &#128049;)
                 CLOWDR combines the group chat features of Slack or IRC with the simplicity of private chat in
                 social networks like Facebook Messenger or GChat. And, every chat has the option to add video or audio.
                 Aside from chat, CLOWDR contains the entire conference program, and organizes the various events' live

--- a/src/components/Lobby/Lobby.js
+++ b/src/components/Lobby/Lobby.js
@@ -285,8 +285,8 @@ class Lobby extends React.Component {
                 Some say that the most valuable part of an academic conference is the "lobby track" - where
                 colleagues meet, catch up, and share
                 casual conversation. To bring the metaphor into the digital world, the digital lobby session
-                allows you to create a small group video chat, and switch between group chats.
-                    The pane on the left shows the active video chats, and the list below shows the users currently looking for a conversation.
+                allows you to create small group video chats and switch between  chats.
+                    The pane on the left shows the active video chats, and the list below shows the users actively looking for a conversation.
 
                     <NewRoomForm style={{display: "none"}} initialName={this.state.requestedName} visible={this.state.visible} />
                 </Typography.Paragraph>

--- a/src/components/Lobby/PresenceForm.js
+++ b/src/components/Lobby/PresenceForm.js
@@ -31,6 +31,7 @@ class PresenceForm extends React.Component {
             presence.set("isAvailable", true);
             presence.set("isDND", false);
             presence.set("isDNT", false);
+            presence.set("isLookingForConversation", false);
             presence.set("isOpenToConversation", false);
             presence.set("isOnline", true);
             presence.set("socialSpace", this.props.auth.activeSpace);

--- a/src/components/Lobby/PresenceForm.js
+++ b/src/components/Lobby/PresenceForm.js
@@ -31,7 +31,7 @@ class PresenceForm extends React.Component {
             presence.set("isAvailable", true);
             presence.set("isDND", false);
             presence.set("isDNT", false);
-            presence.set("isLookingForConversation", false);
+            presence.set("isOpenToConversation", false);
             presence.set("isOnline", true);
             presence.set("socialSpace", this.props.auth.activeSpace);
 
@@ -86,6 +86,7 @@ class PresenceForm extends React.Component {
 
             }
             this.state.presence.set("isLookingForConversation", false);
+            this.state.presence.set("isOpenToConversation", false);
             this.state.presence.set("isAvailable", false);
             this.state.presence.set("isDND", false);
             this.state.presence.set("isDNT", false);
@@ -102,6 +103,8 @@ class PresenceForm extends React.Component {
     availabilityByPresence(presence) {
         if (presence.get("isLookingForConversation")) {
             return "isLookingForConversation";
+        } else if (presence.get("isOpenToConversation")) {
+            return "isOpenToConversation";
         } else if (presence.get("isAvailable")) {
             return "isAvailable";
         } else if (presence.get("isDND")) {
@@ -157,7 +160,9 @@ class PresenceForm extends React.Component {
                     </div>
                 )}
             >
+            {/* BCP: Not sure I got this quite right -- I'm not certain what status="processing" does... */}
                 <Select.Option value="isLookingForConversation"><Badge status="processing" color="green" /><span className="availabilityOption">Looking for conversation</span></Select.Option>
+                <Select.Option value="isOpenToConversation"><Badge color="black" /><span className="availabilityOption">Open to conversation</span></Select.Option>
                 <Select.Option value="isAvailable"><Badge color="geekblue"/><span className="availabilityOption">In a conversation; come
                     join if you like</span></Select.Option>
                 <Select.Option value="isDND"><Badge color="orange"/><span className="availabilityOption">Busy / do not disturb</span></Select.Option>

--- a/src/components/Lobby/UserStatusDisplay.js
+++ b/src/components/Lobby/UserStatusDisplay.js
@@ -50,6 +50,9 @@ class UserStatusDisplay extends React.Component{
             } else if (this.state.presence.get("isAvailable")) {
                 presenceDesc = "In a conversation; come join if you like";
                 badgeColor = "geekblue";
+            } else if (this.state.presence.get("isOpenToConversation")) {
+                presenceDesc = "Open to conversation";
+                badgeColor = "black";
             } else if (this.state.presence.get("isDND")) {
                 presenceDesc = "Busy / do not disturb";
                 badgeColor = "orange";


### PR DESCRIPTION
This PR combines a few wording improvements with one more significant change: Adding a new "default status" that displays as "Open to conversation."  (Still not sure this is actually the right default -- having a lot of zombies that are advertising "open to conversation" may not be that useful -- but even so I think it is a useful thing to have.  We may want to add one more for a real default.)

It is not quite working, for reasons I can't understand -- selecting "open to conversation" does change the color of the status dot, but it also makes the UI component unresponsive. 
