### PR TITLE
Find room by name instead of by id in ProgramSession

### DIFF
--- a/src/components/Admin/Program/Sessions/ProgramSessions.js
+++ b/src/components/Admin/Program/Sessions/ProgramSessions.js
@@ -54,7 +54,7 @@ class ProgramSessions extends React.Component {
     async onCreate(values) {
         console.log("OnCreate! " + values.title)
         var _this = this;
-        let room = this.state.rooms.find(r => r.id == values.room);
+        let room = this.state.rooms.find(r => r.get("name") === values.room);
         if (!room)
             console.log('Invalid room ' + values.room);
 

--- a/src/components/Admin/Program/Sessions/ProgramSessions.js
+++ b/src/components/Admin/Program/Sessions/ProgramSessions.js
@@ -136,7 +136,7 @@ class ProgramSessions extends React.Component {
             session.set("startTime", values.startTime.toDate());
             session.set("endTime", values.endTime.toDate());
             session.set("items", values.items);
-            let room = this.state.rooms.find(r => r.id == values.room);
+            let room = this.state.rooms.find(r => r.get("name") === values.room);
             if (!room)
                 console.log('Invalid room ' + values.room);
             session.set("room", room);


### PR DESCRIPTION
Find room by `name`  instead of by `id` in ProgramSession's `onCreate` and `onUpdate`. The `values.room` is the room name rather than the room id.