### PR TITLE
Combine ICFP banner with menu

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -163,6 +163,15 @@
     right: 0;
     background-color: white;
     border-bottom: 1px solid #e7e7e7;
+    display: flex;
+}
+
+.ant-layout-header {
+    flex: 1 0;
+    margin-left: 20px;
+    height: auto;
+    padding-top: 5.5px;
+    padding-bottom: 5.5px;
 }
 
 .lobbySessionTab {


### PR DESCRIPTION
From tech support:
>In case this is easy, to save vertical space, I'd recommend combining the "ICFP 2020" banner at the top with the menu underneath.

It's pretty easy... although I'd test it first. In particular there's an index.less file that sets properties for ant-layout-header, I'm not sure if App.css overrides it. But if you set these properties in Chrome it looks reasonable.