### PR TITLE
Fixes #36. Set `overflow-y` to `visible` for bottom text-chat window.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -488,7 +488,7 @@ div.availabilityOptionsOpen  span.availabilityOption{
 .embeddedChatListContainer{
     align-items: flex-start;
     align-content: flex-start;
-    overflow-y: auto;
+    overflow-y: visible;
     display: flex;
     flex-direction: column-reverse;
     overflow-wrap: break-word;


### PR DESCRIPTION
The behaviour of `overflow` with `display: flex` is not particularly stable. In Firefox and (some versions of) Edge, `overflow-y: auto` does not result in a scroll bar. By forcing the overflow to be visible, it at least always shows the scrollbar (at the expense of showing it when it is not needed i.e. in chats with very few messages).

See Issue #36.